### PR TITLE
Add prefix and includedir to cppad.pc.in

### DIFF
--- a/pkgconfig/cppad.pc.in
+++ b/pkgconfig/cppad.pc.in
@@ -11,6 +11,9 @@
 # -----------------------------------------------------------------------------
 # This file is used with pkg-config to include CppAD after it is installed
 
+prefix=@prefix@
+includedir=@includedir@/cppad
+
 Name:         cppad
 Description:  @cppad_description@
 Version:      @cppad_version@


### PR DESCRIPTION
These are necessary for OS/configure to pick up cppad (and also Ipopt, Bonmin, and Couenne) correctly.

I'm not sure whether the cmake build system will populate these automatically or if anything else needs to be added.