### PR TITLE
rename libs and requires variables in configure too,

### DIFF
--- a/configure
+++ b/configure
@@ -631,6 +631,8 @@ ipopt_prefix
 eigen_prefix
 adolc_prefix
 cppad_SOURCE_DIR
+cppad_abs_includedir
+cmake_install_prefix
 cppad_pkgconfig_requires
 cppad_pkgconfig_libs
 cppad_pkgconfig_cflags
@@ -7889,7 +7891,7 @@ else
 	cppad_pkgconfig_libs_value="-L$prefix/lib"
 fi
 if test "$POSTFIX_DIR" != "" ; then
-	cppad_pkgconfig_cflags_value="$cppad_cflags_value/$POSTFIX_DIR"
+	cppad_pkgconfig_cflags_value="$cppad_pkgconfig_cflags_value/$POSTFIX_DIR"
 	cppad_pkgconfig_libs_value="$cppad_pkgconfig_libs_value/$POSTFIX_DIR"
 fi
 if test "$IPOPT_DIR" == "" ; then
@@ -7904,6 +7906,10 @@ cppad_pkgconfig_cflags="$cppad_pkgconfig_cflags_value"
 cppad_pkgconfig_libs="$cppad_pkgconfig_libs_value"
 
 cppad_pkgconfig_requires="$cppad_pkgconfig_requires_value"
+
+cmake_install_prefix="$prefix"
+
+cppad_abs_includedir="$includedir"
 
 cppad_SOURCE_DIR=${ABS_TOP_SRCDIR}
 

--- a/configure.ac
+++ b/configure.ac
@@ -742,7 +742,7 @@ else
 	cppad_pkgconfig_libs_value="-L$prefix/lib"
 fi
 if test "$POSTFIX_DIR" != "" ; then
-	cppad_pkgconfig_cflags_value="$cppad_cflags_value/$POSTFIX_DIR"
+	cppad_pkgconfig_cflags_value="$cppad_pkgconfig_cflags_value/$POSTFIX_DIR"
 	cppad_pkgconfig_libs_value="$cppad_pkgconfig_libs_value/$POSTFIX_DIR"
 fi
 if test "$IPOPT_DIR" == "" ; then
@@ -755,6 +755,8 @@ fi
 AC_SUBST(cppad_pkgconfig_cflags,   "$cppad_pkgconfig_cflags_value")
 AC_SUBST(cppad_pkgconfig_libs,     "$cppad_pkgconfig_libs_value")
 AC_SUBST(cppad_pkgconfig_requires, "$cppad_pkgconfig_requires_value")
+AC_SUBST(cmake_install_prefix,     "$prefix")
+AC_SUBST(cppad_abs_includedir,     "$includedir")
 dnl
 dnl names set here so cppad.pc-uninstalled works both with cmake and autoconf
 AC_SUBST(cppad_SOURCE_DIR,  ${ABS_TOP_SRCDIR} )


### PR DESCRIPTION
add a few AC_SUBST variables that cmake sets but configure doesnt

This makes the autotools build compatible with the additions from 5684f3f0ece5c61d1f5e05df4937b0b7beff444a, ref #2