### PR TITLE
fix color_method after clear on sparse_hessian_work

### DIFF
--- a/cppad/local/sparse_hessian.hpp
+++ b/cppad/local/sparse_hessian.hpp
@@ -312,7 +312,7 @@ class sparse_hessian_work {
 		{ }
 		/// inform CppAD that this information needs to be recomputed
 		void clear(void)
-		{	color_method = "cppad";
+		{	color_method = "cppad.symmetric";
 			row.clear();
 			col.clear();
 			order.clear();


### PR DESCRIPTION
The constructor for sparse_hessian_work sets color_method to "cppad.symmetric"  This should be the result after a call to clear() as well.  Otherwise, havoc ensues and chaos reigns (i.e., it triggers an assert that the color method is invalid).