### PR TITLE
2018-10-06: test_more/compare_c/det_by_minor.c - ERRORFIX

### DIFF
--- a/cppad/local/subgraph/init_rev.hpp
+++ b/cppad/local/subgraph/init_rev.hpp
@@ -122,7 +122,7 @@ void subgraph_info::init_rev(
 			// only mark both first UserOp for each call as depending
 			// on the selected independent variables
 			case UserOp:
-			begin_atomic_call  = not begin_atomic_call;
+			begin_atomic_call  = ! begin_atomic_call;
 			if( begin_atomic_call )
 			{	get_argument_variable(random_itr, i_op, argument_variable, work);
 				for(size_t j = 0; j < argument_variable.size(); ++j)

--- a/test_more/compare_c/det_by_minor.c
+++ b/test_more/compare_c/det_by_minor.c
@@ -383,6 +383,7 @@ $head Source Code$$
 $srccode%cpp% */
 bool correct_det_by_minor(void)
 {	double a[9], det, check;
+	double eps99 = 99.0 * DBL_EPSILON;
 
 	random_seed(123);
 	uniform_01(9, a);
@@ -396,7 +397,6 @@ bool correct_det_by_minor(void)
 	check -= a[1] * ( a[3] * a[8] - a[5] * a[6] );
 	check += a[2] * ( a[3] * a[7] - a[4] * a[6] );
 
-	double eps99 = 99.0 * DBL_EPSILON;
 	if( fabs(det / check - 1.0) < eps99 )
 		return true;
 	return false;


### PR DESCRIPTION
 correct_det_by_minor(): move double eps99 to top of function to remove error C2143 syntax error : missing ';' before 'type'