### PR TITLE
Add include of cctype for json_lexer in which std::isdigit is used

### DIFF
--- a/cppad_lib/json_lexer.cpp
+++ b/cppad_lib/json_lexer.cpp
@@ -15,6 +15,7 @@ CppAD: C++ Algorithmic Differentiation: Copyright (C) 2003-19 Bradley M. Bell
 # include <cppad/utility/to_string.hpp>
 # include <cppad/utility/thread_alloc.hpp>
 
+# include <cctype>
 
 // BEGIN_CPPAD_LOCAL_GRAPH_NAMESPACE
 namespace CppAD { namespace local { namespace graph {


### PR DESCRIPTION
The `std::isdigit` function is used in the `json_lexer.cpp` file, but the header `cctype` that defines it was never included. 

I guess that on some platforms this works fine thanks to transitive includes, but even on those platforms new version of the standard headers could be refactor to stop including `cctype`, and this could break the code, so including `cctype` may be a good idea.

Related PR: https://github.com/conda-forge/staged-recipes/pull/13628 . 