### PR TITLE
Set CMAKE_BUILD_TYPE only if not defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,15 +203,17 @@ command_line_arg(cppad_debug_which "debug_all" STRING
     "debug_even, debug_odd, debug_all, or debug_none"
 )
 assert_value_in_set(cppad_debug_which debug_even debug_odd debug_all debug_none)
-IF( "${cppad_debug_which}" STREQUAL debug_all)
-    SET(CMAKE_BUILD_TYPE Debug)
-ELSEIF( "${cppad_debug_which}" STREQUAL debug_none)
-    SET(CMAKE_BUILD_TYPE Release)
-ELSEIF( "${cppad_debug_which}" STREQUAL debug_odd)
-    SET(CMAKE_BUILD_TYPE Debug)
-ELSEIF( "${cppad_debug_which}" STREQUAL debug_even)
-    SET(CMAKE_BUILD_TYPE Releaser)
-ENDIF( "${cppad_debug_which}" STREQUAL debug_all)
+IF(NOT CMAKE_BUILD_TYPE)
+  IF( "${cppad_debug_which}" STREQUAL debug_all)
+      SET(CMAKE_BUILD_TYPE Debug)
+  ELSEIF( "${cppad_debug_which}" STREQUAL debug_none)
+      SET(CMAKE_BUILD_TYPE Release)
+  ELSEIF( "${cppad_debug_which}" STREQUAL debug_odd)
+      SET(CMAKE_BUILD_TYPE Debug)
+  ELSEIF( "${cppad_debug_which}" STREQUAL debug_even)
+      SET(CMAKE_BUILD_TYPE Releaser)
+  ENDIF( "${cppad_debug_which}" STREQUAL debug_all)
+ENDIF(NOT CMAKE_BUILD_TYPE)
 #
 # include_eigen
 # include_adolc


### PR DESCRIPTION
Related to #113 