### PR TITLE
use cppad_prefix instead of prefix in pkgconfig

### DIFF
--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -140,7 +140,7 @@ MACRO(add_to_set variable_name element)
 ENDMACRO(add_to_set variable_name element)
 # -----------------------------------------------------------------------------
 # initialize
-SET(cppad_libdir_list "-L${prefix}/${cppad_libdir}")
+SET(cppad_libdir_list "-L${cppad_prefix}/${cppad_libdir}")
 SET(cppad_lib_list    "-l${cppad_lib}")
 SET(cppad_requires         "")
 SET(cppad_libs_private     "")


### PR DESCRIPTION
Otherwise the generated pkgconfig has:
```
Libs:                  -LNOTFOUND/lib -lcppad_lib
```