### PR TITLE
Add support for Eigen 3.4.0

### DIFF
--- a/include/cppad/core/base_limits.hpp
+++ b/include/cppad/core/base_limits.hpp
@@ -58,6 +58,8 @@ template <> class numeric_limits<Base>\
     {   return static_cast<Base>( std::numeric_limits<Other>::epsilon() ); }\
     static Base quiet_NaN(void) \
     {   return static_cast<Base>( std::numeric_limits<Other>::quiet_NaN() ); }\
+    static Base infinity(void) \
+    {   return static_cast<Base>( std::numeric_limits<Other>::infinity() ); }\
     static const int digits10 = std::numeric_limits<Other>::digits10;\
 };
 /* %$$

--- a/include/cppad/core/numeric_limits.hpp
+++ b/include/cppad/core/numeric_limits.hpp
@@ -34,6 +34,8 @@ $icode%max% = numeric_limits<%Float%>::max()
 %$$
 $icode%nan% = numeric_limits<%Float%>::quiet_NaN()
 %$$
+$icode%inf% = numeric_limits<%Float%>::infinity()
+%$$
 $codei%numeric_limits<%Float%>::digits10%$$
 
 $head CppAD::numeric_limits$$
@@ -42,7 +44,8 @@ $codei%
     static %Float% CppAD::numeric_limits<%Float%>::%fun%(%void%)
 %$$
 where $icode fun$$ is
-$code epsilon$$, $code min$$, $code max$$, and $code quiet_NaN$$.
+$code epsilon$$, $code min$$, $code max$$, $code quiet_NaN$$,
+and $code infinity$$.
 (Note that $code digits10$$ is member variable and not a function.)
 
 $head std::numeric_limits$$
@@ -116,6 +119,19 @@ $codei%
     %nan% != %nan%
 %$$
 
+$head infinity$$
+The result $icode inf$$ is equal to the
+positive infinite value and has prototype
+$codei%
+    %Float% %inf%
+%$$
+The file $cref num_limits.cpp$$
+tests the value $icode inf$$ by checking that the following are true
+$codei%
+    %inf% + 100 == %inf%
+    isnan(%inf% - %inf%)
+%$$
+
 $head digits10$$
 The member variable $code digits10$$ has prototype
 $codei%
@@ -187,6 +203,14 @@ public:
         );
         return Float(0);
     }
+    /// positive infinite value
+    static Float infinity(void)
+    {   CPPAD_ASSERT_KNOWN(
+        false,
+        "numeric_limits<Float>::infinity() is not specialized for this Float"
+        );
+        return Float(0);
+    }
     /// number of decimal digits
     static const int digits10 = -1;
 };
@@ -207,6 +231,9 @@ public:
     /// not a number
     static AD<Base> quiet_NaN(void)
     {   return AD<Base>( numeric_limits<Base>::quiet_NaN() ); }
+    /// positive infinite value
+    static AD<Base> infinity(void)
+    {   return AD<Base>( numeric_limits<Base>::infinity() ); }
     /// number of decimal digits
     static const int digits10 = numeric_limits<Base>::digits10;
 };

--- a/include/cppad/example/cppad_eigen.hpp
+++ b/include/cppad/example/cppad_eigen.hpp
@@ -11,9 +11,6 @@ Secondary License when the conditions for such availability set forth
 in the Eclipse Public License, Version 2.0 are satisfied:
       GNU General Public License, Version 2.0 or later.
 ---------------------------------------------------------------------------- */
-// cppad.hpp gets included at the end
-# define EIGEN_MATRIXBASE_PLUGIN <cppad/example/eigen_plugin.hpp>
-# include <Eigen/Core>
 
 /*
 $begin cppad_eigen.hpp$$
@@ -80,6 +77,16 @@ namespace CppAD {
     // numeric_limits<Float>
     template <class Float>  class numeric_limits;
 }
+
+namespace std {
+    template <class Base> bool isinf(const CppAD::AD<Base> &x);
+    template <class Base> bool isnan(const CppAD::AD<Base> &x);
+}
+
+// cppad.hpp gets included at the end
+# define EIGEN_MATRIXBASE_PLUGIN <cppad/example/eigen_plugin.hpp>
+# include <Eigen/Core>
+
 /* %$$
 $head Eigen NumTraits$$
 Eigen needs the following definitions to work properly
@@ -134,6 +141,14 @@ namespace Eigen {
         // number of decimal digits that can be represented without change.
         static int digits10(void)
         {   return CppAD::numeric_limits< CppAD::AD<Base> >::digits10; }
+
+        // not a number
+        static CppAD::AD<Base> quiet_NaN(void)
+        {   return CppAD::numeric_limits< CppAD::AD<Base> >::quiet_NaN(); }
+
+        // positive infinite value
+        static CppAD::AD<Base> infinity(void)
+        {   return CppAD::numeric_limits< CppAD::AD<Base> >::infinity(); }
     };
 }
 /* %$$
@@ -189,6 +204,15 @@ namespace CppAD {
 }
 //
 # include <cppad/cppad.hpp>
+
+namespace std {
+    template <class Base> bool isinf(const CppAD::AD<Base> &x)
+    {   return isinf(CppAD::Value(x)); }
+
+    template <class Base> bool isnan(const CppAD::AD<Base> &x)
+    {   return isnan(CppAD::Value(x)); }
+}
+
 /* %$$
 $end
 */

--- a/test_more/general/cppad_eigen.cpp
+++ b/test_more/general/cppad_eigen.cpp
@@ -40,12 +40,23 @@ bool cppad_eigen(void)
         std::numeric_limits<double>::max();
     ok &= traits::lowest() ==
         std::numeric_limits<double>::min();
+    ok &= std::isnan(traits::quiet_NaN());
+    ok &= std::isinf(traits::infinity());
 
     AD<double> x = 2.0;
     ok  &= conj(x)  == x;
     ok  &= real(x)  == x;
     ok  &= imag(x)  == 0.0;
     ok  &= abs2(x)  == 4.0;
+
+    ok  &= (!std::isinf(x));
+    ok  &= (!std::isnan(x));
+
+    x = traits::quiet_NaN();
+    ok  &= std::isnan(x);
+
+    x = traits::infinity();
+    ok  &= std::isinf(x);
 
     // Outputing a matrix used to fail before partial specialization of
     // struct significant_decimals_default_impl in cppad_eigen.hpp.

--- a/test_more/general/num_limits.cpp
+++ b/test_more/general/num_limits.cpp
@@ -138,6 +138,23 @@ namespace {
         //
         return ok;
     }
+    // -----------------------------------------------------------------
+    template <class Type>
+    bool check_infinity(void)
+    {   bool ok    = true;
+        typedef extern_value<Type> value;
+        value inf( CppAD::numeric_limits<Type>::infinity() );
+        value hun( Type(100) );
+
+        value tmp( Type(0) );
+
+        tmp.set( inf.get() + hun.get() );
+        ok &= inf.get() == tmp.get();
+
+        tmp.set( inf.get() - inf.get() );
+        ok &= CppAD::isnan( tmp.get() );
+        return ok;
+    }
 }
 
 bool num_limits(void)
@@ -194,6 +211,19 @@ bool num_limits(void)
     ok &= check_quiet_NaN< AD<double> >();
     ok &= check_quiet_NaN< AD< std::complex<float> > >();
     ok &= check_quiet_NaN< AD< std::complex<double> > >();
+
+    // -------------------------------------------------------------------
+    // infinity for Base types defined by CppAD
+    ok &= check_infinity<float>();
+    ok &= check_infinity<double>();
+    ok &= check_infinity< std::complex<float> >();
+    ok &= check_infinity< std::complex<double> >();
+
+    // infinity for some AD types.
+    ok &= check_infinity< AD<float> >();
+    ok &= check_infinity< AD<double> >();
+    ok &= check_infinity< AD< std::complex<float> > >();
+    ok &= check_infinity< AD< std::complex<double> > >();
 
     return ok;
 }


### PR DESCRIPTION
We provide a specialization of Eigen::NumTraits
for CppAD::AD classes. However, in Eigen 3.4.0
as a result of commit
https://gitlab.com/libeigen/eigen/-/commit/bde674164
Eigen (in Core/MathFunctionsImpl.h) now tries to use
NumTraits<RealScalar>::infinity() and
NumTraits<RealScalar>::quiet_NaN(), which our
specialization does not provide. Add these two methods,
and also allow Eigen to call std::isinf() and
std::isnan() on AD classes. Closes #139.