### PR TITLE
Add std::isfinite specialization for Eigen 3.4

### DIFF
--- a/include/cppad/example/cppad_eigen.hpp
+++ b/include/cppad/example/cppad_eigen.hpp
@@ -226,7 +226,7 @@ namespace std {
     {   return isinf(CppAD::Value( CppAD::Var2Par(x) ) ); }
 
     template <class Base> bool isfinite(const CppAD::AD<Base> &x)
-    {   return !isinf(x); }
+    {   return isfinite(CppAD::Value( CppAD::Var2Par(x) ) ); }
 
     template <class Base> bool isnan(const CppAD::AD<Base> &x)
     {   return isnan(CppAD::Value( CppAD::Var2Par(x) ) ); }

--- a/include/cppad/example/cppad_eigen.hpp
+++ b/include/cppad/example/cppad_eigen.hpp
@@ -81,6 +81,7 @@ Next declare some template specializations in std namespace:
 $srccode%cpp% */
 namespace std {
     template <class Base> bool isinf(const CppAD::AD<Base> &x);
+    template <class Base> bool isfinite(const CppAD::AD<Base> &x);
     template <class Base> bool isnan(const CppAD::AD<Base> &x);
 }
 /* %$$
@@ -223,6 +224,9 @@ $srccode%cpp% */
 namespace std {
     template <class Base> bool isinf(const CppAD::AD<Base> &x)
     {   return isinf(CppAD::Value( CppAD::Var2Par(x) ) ); }
+
+    template <class Base> bool isfinite(const CppAD::AD<Base> &x)
+    {   return !isinf(x); }
 
     template <class Base> bool isnan(const CppAD::AD<Base> &x)
     {   return isnan(CppAD::Value( CppAD::Var2Par(x) ) ); }


### PR DESCRIPTION
When using Eigen 3.4 it may attempt to call
std::isfinite() on AD objects (see isfinite_impl()
in Eigen/src/Core/MathFunctions.h). Provide a suitable
specialization, similar to those provided for std::isinf
and std::isnan in PR #140.