### PR TITLE
Fix build issue with LoadLibrary when building with UNICODE

### DIFF
--- a/cppad_lib/link_dll_lib.cpp
+++ b/cppad_lib/link_dll_lib.cpp
@@ -23,7 +23,7 @@ namespace CppAD { // BEGIN_CPPAD_NAMESPACE
 //
 //  dlopen
 void* link_dll_lib::dlopen(const char *filename, int flag)
-{  HINSTANCE hinstance = LoadLibrary(filename);
+{  HINSTANCE hinstance = LoadLibraryA(filename);
    return reinterpret_cast<void*>( hinstance );
 }
 // dlsym


### PR DESCRIPTION
Per the *UTF-8 Everywhere Manifesto*, it's best to not rely on the legacy ANSI .vs UNICODE macros for Win32 functions that take strings. Since you explicitly use a ``const char*`` for the call to ``LoadLibrary`` you should explicitly use the ``LoadLibraryA`` method.

> This causes problems when trying to build your library using vcpkg manager when the setup adds the recommended UNICODE _UNICODE defines.
