### PR TITLE
Specify shell for bin/get_eigen.sh script

### DIFF
--- a/bin/get_eigen.sh
+++ b/bin/get_eigen.sh
@@ -1,3 +1,4 @@
+#! /bin/bash -e
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
 # SPDX-FileCopyrightText: Bradley M. Bell <bradbell@seanet.com>
 # SPDX-FileContributor: 2003-24 Bradley M. Bell


### PR DESCRIPTION
This commit prevents errors for people using sh, zsh, or other shells that don't support '[[' syntax. All the other scripts of the form bing/get_*.sh specify the shell.