### PR TITLE
Set location of Trilinos package and find it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,8 @@ pkgconfig_info(ipopt ${system_include})
 prefix_info(colpack ${system_include} )
 #
 # package = sacado
+set(Trilinos_DIR "./build/prefix/lib64/cmake/Trilinos")
+find_package(Trilinos REQUIRED)
 prefix_info(sacado ${system_include} )
 #
 # package = fadbad


### PR DESCRIPTION
This change is required to ensure that all tests pass when sacado tests are enabled.

On Ubuntu 22.04 LTS, the very last test fails because the Trilinos package is not loaded, which prevents the sacado speed test from building because the required libraries and corresponding symbols are not present. The minor change I added ensures that Trilinos package is found. The following commands can be used to test the last test on the current version fails, but that all tests with the additional tweak I added pass. Here are the commands to reproduce:

1. sudo apt-get update
2. sudo apt-get upgrade
3. sudo apt install python3 python-is-python3
4. pip3 install xrst
5. source ~/.profile
6. sudo apt-get install clang libclang-dev libopenmpi-dev openmpi-bin libeigen3-dev libboost-all-dev libhwloc-dev libpthread-stubs0-dev libadolc-dev coinor-libipopt-dev libcolpack-dev libomp-dev swig python3-dev libmetis-dev
7. git clone https://github.com/coin-or/CppAD.git cppad.git
8. export LD_LIBRARY_PATH=/home/bulky/explicit_solutions_through_backprop/cppad.git/build/prefix/lib64:/home/bulky/explicit_solutions_through_backprop/cppad.git/build/prefix/lib:$LD_LIBRARY_PATH
9. export LD_RUN_PATH=/home/bulky/explicit_solutions_through_backprop/cppad.git/build/prefix/lib64:/home/bulky/explicit_solutions_through_backprop/cppad.git/build/prefix/lib:$LD_RUN_PATH
10. export CMAKE_PREFIX_PATH=/home/bulky/explicit_solutions_through_backprop/cppad.git/build/prefix
11. export CMAKE_INCLUDE_PATH=$CMAKE_PREFIX_PATH/include
12. export CMAKE_LIBRARY_PATH=$CMAKE_PREFIX_PATH/lib64:$CMAKE_PREFIX_PATH/lib:$CMAKE_LIBRARY_PATH
13. cd cppad.git
14. bin/get_colpack.sh
15. bin/get_adolc.sh
16. bin/get_fadbad.sh
17. bin/get_ipopt.sh
18. bin/get_sacado.sh
19. bin/get_cppadcg.sh
20. cd build
21. ln -s prefix/lib64/libColPack.so prefix/lib/libColPack.so
22. cmake .. -Dinclude_adolc=TRUE -Dinclude_ipopt=TRUE -Dinclude_cppadcg=TRUE -Dcolpack_prefix=./prefix/ -Dfadbad_prefix=./prefix/ -Dsacado_prefix=./prefix/ -Dinclude_doc=TRUE -DCMAKE_BUILD_TYPE=Debug -DTrilinos_DIR=$(pwd)/prefix/
23. make check

Two additional issues not fixed by this pull request:
1. The following command was required:
```
sudo apt-get remove libmumps-dev libmumps-seq-dev libmumps-seq-5.4
```
If this command isn't run, cpp_ipopt_test tends to link against libdmumps_seq-5.4.so causing a conflict between two mumps libraries. Uninstalling the system packages above prevents this conflict.
2. The symlink introduced in step 21 could cause issues for people. I shouldn't have to introduce this additional step. I'm not sure it is required on all operating systems. However, I noticed one of the other open Issues was caused by a Coloring Package failure on FreeBSD. Not sure whether this issue fixes that.

Here's the output of make check showing that the commands above indeed pass all the tests:

https://dpaste.org/AwAt7