### PR TITLE
Add `NumTraits::digits` for Eigen 5 support

### DIFF
--- a/include/cppad/core/base_limits.hpp
+++ b/include/cppad/core/base_limits.hpp
@@ -53,6 +53,7 @@ template <> class numeric_limits<Base>\
     {  return static_cast<Base>( std::numeric_limits<Other>::quiet_NaN() ); }\
     static Base infinity(void) \
     {  return static_cast<Base>( std::numeric_limits<Other>::infinity() ); }\
+    static const int digits = std::numeric_limits<Other>::digits;\
     static const int digits10 = std::numeric_limits<Other>::digits10;\
     static const int max_digits10 = std::numeric_limits<Other>::max_digits10;\
 };

--- a/include/cppad/core/numeric_limits.hpp
+++ b/include/cppad/core/numeric_limits.hpp
@@ -23,6 +23,7 @@ Syntax
 | *max* = ``numeric_limits`` < *Float* >:: ``max`` ()
 | *nan* = ``numeric_limits`` < *Float* >:: ``quiet_NaN`` ()
 | *inf* = ``numeric_limits`` < *Float* >:: ``infinity`` ()
+| ``numeric_limits`` < *Float* >:: ``digits``
 | ``numeric_limits`` < *Float* >:: ``digits10``
 | ``numeric_limits`` < *Float* >:: ``max_digits10``
 
@@ -35,7 +36,7 @@ The functions above and have the prototype
 where *fun* is
 ``epsilon`` , ``min`` , ``max`` , ``quiet_NaN`` , and ``infinity`` .
 
-The values ``digits10`` and ``max_digits10`` are
+The values ``digits`` , ``digits10`` , and ``max_digits10`` are
 member variable and not a functions.
 
 std::numeric_limits
@@ -128,6 +129,15 @@ tests the value *inf* by checking that the following are true
 | |tab| *inf* + 100 == *inf*
 | |tab| ``isnan`` ( *inf* ``-`` *inf* )
 
+digits
+******
+The member variable ``digits`` has prototype
+
+    ``static const int numeric_limits`` < *Float* >:: ``digits``
+
+It is the number of base-radix digits that can be represented by a
+*Float* value without change; this is the digits of the mantissa.
+
 digits10
 ********
 The member variable ``digits10`` has prototype
@@ -219,6 +229,8 @@ public:
         );
         return Float(0);
     }
+    /// number of base-radix digits
+    static const int digits = -1;
     /// number of decimal digits
     static const int digits10 = -1;
 };
@@ -242,6 +254,8 @@ public:
     /// positive infinite value
     static AD<Base> infinity(void)
     {   return AD<Base>( numeric_limits<Base>::infinity() ); }
+    /// number of base-radix digits
+    static const int digits       = numeric_limits<Base>::digits;
     /// number of decimal digits
     static const int digits10     = numeric_limits<Base>::digits10;
     static const int max_digits10 = numeric_limits<Base>::max_digits10;

--- a/include/cppad/example/cppad_eigen.hpp
+++ b/include/cppad/example/cppad_eigen.hpp
@@ -128,6 +128,10 @@ namespace Eigen {
         static CppAD::AD<Base> highest(void)
         {  return CppAD::numeric_limits< CppAD::AD<Base> >::max(); }
 
+        // number of base-radix digits that can be represented without change.
+        static int digits(void)
+        {  return CppAD::numeric_limits< CppAD::AD<Base> >::digits; }
+
         // number of decimal digits that can be represented without change.
         static int digits10(void)
         {  return CppAD::numeric_limits< CppAD::AD<Base> >::digits10; }

--- a/test_more/general/base_alloc.cpp
+++ b/test_more/general/base_alloc.cpp
@@ -45,6 +45,9 @@ bool test_numeric_limits(void)
     base_alloc nan = Value( CppAD::numeric_limits<my_ad>::quiet_NaN() );
     ok            &= *nan.ptrdbl_ != *nan.ptrdbl_;
     //
+    int   digits = CppAD::numeric_limits<my_ad>::digits;
+    ok            &= digits == std::numeric_limits<double>::digits;
+    //
     int   digits10 = CppAD::numeric_limits<my_ad>::digits10;
     ok            &= digits10 == std::numeric_limits<double>::digits10;
     //


### PR DESCRIPTION
The random number generator in Eigen 5 calls `NumTraits<Scalar>::digits()`. This is not currently implemented for CppAD types, causing a compile-time failure. Add such an implementation that simply uses `std::numeric_limits<T>::digits`. Closes #250.